### PR TITLE
Force #rooms width to match the content width for background

### DIFF
--- a/pages/programs.vue
+++ b/pages/programs.vue
@@ -270,7 +270,7 @@ export default Programs;
 	margin: 0;
 
 	li {
-		flex: 1 0 calc(((100% - 7 * 0.5em) / 8));
+		flex: 1 0 calc(((100% - (var(--length) - 1) * 0.5em) / var(--length)));
 		font-size: smaller;
 		color: rgba(0, 0, 0, 0.4);
 		&:not(:first-child) {
@@ -287,6 +287,7 @@ export default Programs;
 
 	@media only screen and (min-width: 1280px) {
 		display: flex;
+		width: calc((100% - 7 * 0.5em) / 8 * var(--length) + (var(--length) - 1) * 0.5em);
 	}
 }
 


### PR DESCRIPTION
Before:

<img width="1464" alt="螢幕快照 2019-06-12 下午4 08 30" src="https://user-images.githubusercontent.com/16474/59334463-211b6900-8d2d-11e9-96ee-5a5c12d06396.png">

Looks like its not possible to extend container automatically.
So use calc to calculate it now.